### PR TITLE
allow case insensitive values for --target-filesystem

### DIFF
--- a/WoeUSB/core.py
+++ b/WoeUSB/core.py
@@ -645,7 +645,7 @@ def setup_arguments():
                         help="Specify label for the newly created file system in --device creation method")
     parser.add_argument("--workaround-bios-boot-flag", action="store_true",
                         help="Workaround BIOS bug that won't include the device in boot menu if non of the partition's boot flag is toggled")
-    parser.add_argument("--target-filesystem", "--tgt-fs", choices=["FAT", "NTFS"], default="FAT",
+    parser.add_argument("--target-filesystem", "--tgt-fs", choices=["FAT", "NTFS"], default="FAT", type=str.upper,
                         help="Specify the filesystem to use as the target partition's filesystem.")
     parser.add_argument('--for-gui', action="store_true", help=argparse.SUPPRESS)
 


### PR DESCRIPTION
people being wrong on the internet is normal but when following a blog: https://www.linuxuprising.com/2020/10/how-to-make-bootable-windows-10-usb-on.html i tried to use ntfs as the value