### PR TITLE
support 32bit editions on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yay woeusb-ng
 #### Ubuntu
 
 ```shell
-sudo apt install git p7zip-full python3-pip python3-wxgtk4.0 grub2-common
+sudo apt install git p7zip-full python3-pip python3-wxgtk4.0 grub2-common grub-pc-bin
 ```
 
 #### Fedora (tested on: Fedora Workstation 33)
@@ -49,7 +49,7 @@ sudo pip3 install WoeUSB-ng
 ### Install WoeUSB-ng's Build Dependencies
 #### Ubuntu
 ```shell
-sudo apt install git p7zip-full python3-pip python3-wxgtk4.0 grub2-common
+sudo apt install git p7zip-full python3-pip python3-wxgtk4.0 grub2-common grub-pc-bin
 ```
 #### Arch
 ```shell


### PR DESCRIPTION
this PR adds `grub-pc-bin` to the ubuntu dependencies list, which is necessary to build 32bit editions from a 64bit ubuntu install