### PR TITLE
provide all args for core.cleanup

### DIFF
--- a/WoeUSB/core.py
+++ b/WoeUSB/core.py
@@ -108,7 +108,7 @@ def init(from_cli=True, install_mode=None, source_media=None, target_media=None,
         return [source_fs_mountpoint, target_fs_mountpoint, temp_directory, install_mode, source_media, target_media,
                 workaround_bios_boot_flag, target_filesystem_type, filesystem_label, verbose, debug, parser]
     else:
-        return [source_fs_mountpoint, target_fs_mountpoint, temp_directory]
+        return [source_fs_mountpoint, target_fs_mountpoint, temp_directory, target_media]
 
 
 def main(source_fs_mountpoint, target_fs_mountpoint, source_media, target_media, install_mode, temp_directory,

--- a/WoeUSB/gui.py
+++ b/WoeUSB/gui.py
@@ -393,7 +393,7 @@ class WoeUSB_handler(threading.Thread):
         self.filesystem = filesystem
 
     def run(self):
-        source_fs_mountpoint, target_fs_mountpoint, temp_directory = core.init(
+        source_fs_mountpoint, target_fs_mountpoint, temp_directory, target_media = core.init(
             from_cli=False,
             install_mode="device",
             source_media=self.source,
@@ -405,7 +405,7 @@ class WoeUSB_handler(threading.Thread):
         except SystemExit:
             pass
 
-        core.cleanup(source_fs_mountpoint, target_fs_mountpoint, temp_directory)
+        core.cleanup(source_fs_mountpoint, target_fs_mountpoint, temp_directory, target_media)
 
 
 def run():


### PR DESCRIPTION
this PR fixes the invocation of `core.cleanup` from the GUI, which was missing one required argument