### PR TITLE
Removed inaccurate time duration mentioned in waiting message

### DIFF
--- a/WoeUSB/locale/de/LC_MESSAGES/woeusb.po
+++ b/WoeUSB/locale/de/LC_MESSAGES/woeusb.po
@@ -501,7 +501,7 @@ msgid "Making system realize that partition table has changed..."
 msgstr "Vermittle dem System, dass sich die Partitionstabelle geändert hat…"
 
 #: workaround.py:19
-msgid "Wait 3 seconds for block device nodes to populate..."
+msgid "Waiting for block device nodes to populate..."
 msgstr "Warte 3 Sekunden, bis die Block-Gerätedateien gefüllt sind…"
 
 #: workaround.py:35

--- a/WoeUSB/locale/pl/LC_MESSAGES/woeusb.po
+++ b/WoeUSB/locale/pl/LC_MESSAGES/woeusb.po
@@ -486,7 +486,7 @@ msgid "Making system realize that partition table has changed..."
 msgstr "Powiadamianie systemu że tablica partycji się zmieniła..."
 
 #: workaround.py:19
-msgid "Wait 3 seconds for block device nodes to populate..."
+msgid "Waiting for block device nodes to populate..."
 msgstr "Czekanie 3 sekundy na aktualizacje urządzeń blokowych..."
 
 #: workaround.py:35

--- a/WoeUSB/locale/pt_BR/LC_MESSAGES/woeusb.po
+++ b/WoeUSB/locale/pt_BR/LC_MESSAGES/woeusb.po
@@ -494,7 +494,7 @@ msgid "Making system realize that partition table has changed..."
 msgstr "Fazendo o sistema perceber que a tabela de partição mudou..."
 
 #: workaround.py:19
-msgid "Wait 3 seconds for block device nodes to populate..."
+msgid "Waiting for block device nodes to populate..."
 msgstr ""
 "Aguarde 3 segundos para que os nodes do dispositivo de bloco sejam "
 "preenchidos..."

--- a/WoeUSB/locale/woeusb.pot
+++ b/WoeUSB/locale/woeusb.pot
@@ -388,7 +388,7 @@ msgid "Making system realize that partition table has changed..."
 msgstr ""
 
 #: workaround.py:19
-msgid "Wait 3 seconds for block device nodes to populate..."
+msgid "Waiting for block device nodes to populate..."
 msgstr ""
 
 #: workaround.py:35

--- a/WoeUSB/workaround.py
+++ b/WoeUSB/workaround.py
@@ -16,7 +16,7 @@ def make_system_realize_partition_table_changed(target_device):
     utils.print_with_color(_("Making system realize that partition table has changed..."))
 
     subprocess.run(["blockdev", "--rereadpt", target_device])
-    utils.print_with_color(_("Wait 3 seconds for block device nodes to populate..."))
+    utils.print_with_color(_("Waiting for block device nodes to populate..."))
 
     time.sleep(3)
 


### PR DESCRIPTION
The waiting message said `Wait 3 seconds for block device nodes to populate...` but the waiting time is not always 3 seconds (it usually takes longer than that). So I've removed the "3 seconds" from the message to make it more accurate.