### PR TITLE
Fix: tolerate missing termcolor

### DIFF
--- a/WoeUSB/utils.py
+++ b/WoeUSB/utils.py
@@ -17,8 +17,8 @@ no_color = False
 try:
     import termcolor
 except ImportError:
+    termcolor = None
     print("Module termcolor is not installed, text coloring disabled")
-    no_color = True
 
 gui = None
 verbose = False
@@ -289,7 +289,7 @@ def print_with_color(text, color=""):
             gui.error = text
             sys.exit()
     else:
-        if no_color or color == "":
+        if no_color or color == "" or termcolor is None:
             sys.stdout.write(text + "\n")
         else:
             termcolor.cprint(text, color)


### PR DESCRIPTION
When termcolor is missing, although the intention of the code was to just print without color, the following error is produced:

```
sudo woeusb  /home/x/Downloads/Win10_22H2_English_x64v1.iso --device /dev/sda                                                                                                                                  
Module termcolor is not installed, text coloring disabled
WoeUSB v0.2.10
==============================
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/WoeUSB/core.py", line 714, in run
    main(source_fs_mountpoint, target_fs_mountpoint, source_media, target_media, install_mode, temp_directory,
  File "/usr/lib/python3.11/site-packages/WoeUSB/core.py", line 149, in main
    if utils.check_runtime_parameters(install_mode, source_media, target_media):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/WoeUSB/utils.py", line 85, in check_runtime_parameters
    print_with_color(
  File "/usr/lib/python3.11/site-packages/WoeUSB/utils.py", line 295, in print_with_color
    termcolor.cprint(text, color)
    ^^^^^^^^^
NameError: name 'termcolor' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/woeusb", line 27, in <module>
    WoeUSB.core.run()
  File "/usr/lib/python3.11/site-packages/WoeUSB/core.py", line 719, in run
    utils.print_with_color(error, "red")
  File "/usr/lib/python3.11/site-packages/WoeUSB/utils.py", line 295, in print_with_color
    termcolor.cprint(text, color)
    ^^^^^^^^^
NameError: name 'termcolor' is not defined
```

The problem is that `no_color` is set to True on failure of import, but then overridden in core.py . This  fix uses the classic approach of setting module to None and then checking for it.