### PR TITLE
Add Windows 11 Bypass (TPM, SecureBoot, BitLocker)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ sudo dnf install git p7zip p7zip-plugins python3-pip python3-wxpython4
 ```
 ### 2. Install WoeUSB-ng
 ```shell
-git clone https://github.com/WoeUSB/WoeUSB-ng.git
+git clone https://github.com/Nguyen12345tt/WoeUSB-ng.git
 cd WoeUSB-ng
 sudo pip3 install .
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sudo pip3 install .
 
 ## Installation from source code locally or in virtual environment 
 ```shell
-git clone https://github.com/WoeUSB/WoeUSB-ng.git
+git clone https://github.com/Nguyen12345tt/WoeUSB-ng.git
 cd WoeUSB-ng
 git apply development.patch
 sudo pip3 install -e .

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package contains two programs:
 
 Supported images:
 
-Windows Vista, Windows 7, Window 8.x, Windows 10. All languages and any version (home, pro...) and Windows PE are supported.
+Windows Vista, Windows 7, Window 8.x, Windows 10, Windows 11. All languages and any version (home, pro...) and Windows PE are supported.
 
 Supported bootmodes:
 
@@ -20,32 +20,6 @@ Supported bootmodes:
 * Native UEFI booting is supported for Windows 7 and later images (limited to the FAT filesystem as the target)
 
 This project rewrite of original [WoeUSB](https://github.com/slacka/WoeUSB) 
-
-## Installation
-
-### Arch
-```shell
-yay -S woeusb-ng
-```
-
-### For other distributions
-
-### 1. Install WoeUSB-ng's Dependencies
-#### Ubuntu
-
-```shell
-sudo apt install git p7zip-full python3-pip python3-wxgtk4.0 grub2-common grub-pc-bin parted dosfstools ntfs-3g
-```
-
-#### Fedora (tested on: Fedora Workstation 33)
-```shell
-sudo dnf install git p7zip p7zip-plugins python3-pip python3-wxpython4
-```
-
-### 2. Install WoeUSB-ng
-```shell
-sudo pip3 install WoeUSB-ng
-```
 
 ## Installation from source code
 
@@ -83,9 +57,11 @@ Please note that this will not create menu shortcut and you may need to run gui 
 To remove WoeUSB-ng completely run (needed only when using installation from source code):
 ```shell
 sudo pip3 uninstall WoeUSB-ng
+
 sudo rm /usr/share/icons/WoeUSB-ng/icon.ico \
     /usr/share/applications/WoeUSB-ng.desktop \
     /usr/local/bin/woeusbgui
+
 sudo rmdir /usr/share/icons/WoeUSB-ng/
 ```
 

--- a/WoeUSB/core.py
+++ b/WoeUSB/core.py
@@ -22,8 +22,8 @@ application_name = 'WoeUSB'
 application_version = miscellaneous.__version__
 DEFAULT_NEW_FS_LABEL = 'Windows USB'
 
-application_site_url = 'https://github.com/slacka/WoeUSB'
-application_copyright_declaration = "Copyright © Colin GILLE / congelli501 2013\\nCopyright © slacka et.al. 2017"
+application_site_url = 'https://github.com/Nguyen12345tt/WoeUSB'
+application_copyright_declaration = "Copyright © Colin GILLE / congelli501 2013\\nCopyright © slacka et.al. 2017\\nCopyright © Nguyen12345tt"
 application_copyright_notice = application_name + " is free software licensed under the GNU General Public License version 3(or any later version of your preference) that gives you THE 4 ESSENTIAL FREEDOMS\\nhttps://www.gnu.org/philosophy/"
 
 #: Increase verboseness, provide more information when required
@@ -41,7 +41,7 @@ gui = None
 
 def init(from_cli=True, install_mode=None, source_media=None, target_media=None, workaround_bios_boot_flag=False,
          target_filesystem_type="FAT", filesystem_label=DEFAULT_NEW_FS_LABEL, 
-         bypass_workaround=False, bypass_ms_account=False, disable_bitlocker=False):
+         bypass_hardware_check = False, bypass_ms_account = False, disable_bitlocker=False):
     """
     :param from_cli:
     :type from_cli: bool
@@ -51,7 +51,7 @@ def init(from_cli=True, install_mode=None, source_media=None, target_media=None,
     :param workaround_bios_boot_flag:
     :param target_filesystem_type:
     :param filesystem_label:
-    :param bypass_workaround: Bypass TPM/SecureBoot/RAM
+    :param bypass_hardware_check: Bypass TPM/SecureBoot/RAM
     :param bypass_ms_account: Bypass Microsoft Account Requirement
     :param disable_bitlocker: Disable BitLocker Device Encryption
     :return: List
@@ -72,7 +72,7 @@ def init(from_cli=True, install_mode=None, source_media=None, target_media=None,
     parser = None
     
     # Initialize default flags
-    bypass_workaround_flag = bypass_workaround
+    bypass_hardware_check_flag = bypass_hardware_check
     bypass_ms_account_flag = bypass_ms_account
     disable_bitlocker_flag = disable_bitlocker
 
@@ -106,7 +106,7 @@ def init(from_cli=True, install_mode=None, source_media=None, target_media=None,
         filesystem_label = args.label
         
         # Capture CLI arguments for Windows 11 tweaks
-        bypass_workaround_flag = args.bypass_workaround
+        bypass_hardware_check_flag = args.bypass_hardware_check
         bypass_ms_account_flag = args.bypass_ms_account
         disable_bitlocker_flag = args.disable_bitlocker
 
@@ -124,14 +124,14 @@ def init(from_cli=True, install_mode=None, source_media=None, target_media=None,
         # Added new flags to the return list
         return [source_fs_mountpoint, target_fs_mountpoint, temp_directory, install_mode, source_media, target_media,
                 workaround_bios_boot_flag, skip_legacy_bootloader, target_filesystem_type, filesystem_label, verbose, debug, parser, 
-                bypass_workaround_flag, bypass_ms_account_flag, disable_bitlocker_flag]
+                bypass_hardware_check_flag, bypass_ms_account_flag, disable_bitlocker_flag]
     else:
         return [source_fs_mountpoint, target_fs_mountpoint, temp_directory, target_media]
 
 
 def main(source_fs_mountpoint, target_fs_mountpoint, source_media, target_media, install_mode, temp_directory,
          target_filesystem_type, workaround_bios_boot_flag, parser=None, skip_legacy_bootloader=False, 
-         bypass_workaround_flag=False, bypass_ms_account_flag=False, disable_bitlocker_flag=False):
+         bypass_hardware_check_flag=False, bypass_ms_account_flag=False, disable_bitlocker_flag=False):
     """
     :param parser:
     :param source_fs_mountpoint:
@@ -142,7 +142,7 @@ def main(source_fs_mountpoint, target_fs_mountpoint, source_media, target_media,
     :param temp_directory:
     :param target_filesystem_type:
     :param workaround_bios_boot_flag:
-    :param bypass_workaround_flag: Hardware bypass
+    :param bypass_hardware_check_flag: Hardware bypass
     :param bypass_ms_account_flag: MS Account bypass
     :param disable_bitlocker_flag: BitLocker disable
     :return: 0 - succes; 1 - failure
@@ -214,12 +214,12 @@ def main(source_fs_mountpoint, target_fs_mountpoint, source_media, target_media,
     copy_filesystem_files(source_fs_mountpoint, target_fs_mountpoint)
 
     # --- START WINDOWS 11 TWEAKS LOGIC ---
-    if bypass_workaround_flag or bypass_ms_account_flag or disable_bitlocker_flag:
+    if bypass_hardware_check_flag or bypass_ms_account_flag or disable_bitlocker_flag:
         utils.print_with_color(_("Applying Windows 11 customizations..."), "green")
         if hasattr(utils, 'write_win11_bypass'):
             utils.write_win11_bypass(
                 target_fs_mountpoint,
-                bypass_hardware=bypass_workaround_flag,
+                bypass_hardware=bypass_hardware_check_flag,
                 bypass_ms_account=bypass_ms_account_flag,
                 disable_bitlocker=disable_bitlocker_flag
             )
@@ -684,7 +684,7 @@ def setup_arguments():
                         help="Specify the filesystem to use as the target partition's filesystem.")
     
     # --- NEW ARGUMENTS ---
-    parser.add_argument("--bypass-workaround", action="store_true",
+    parser.add_argument("--bypass_hardware_check", action="store_true",
                         help="Bypass Windows 11 TPM 2.0 / Secure Boot requirements.")
     parser.add_argument("--bypass-ms-account", action="store_true",
                         help="Bypass Microsoft Account Requirement (allows offline account creation).")
@@ -758,13 +758,13 @@ def run():
         install_mode, source_media, target_media, \
         workaround_bios_boot_flag, skip_legacy_bootloader, target_filesystem_type, \
         new_file_system_label, verbose, debug, parser, \
-        bypass_workaround_flag, bypass_ms_account_flag, disable_bitlocker_flag = result
+        bypass_hardware_check_flag, bypass_ms_account_flag, disable_bitlocker_flag = result
 
     try:
         # Updated main call to include new flags
         main(source_fs_mountpoint, target_fs_mountpoint, source_media, target_media, install_mode, temp_directory,
              target_filesystem_type, workaround_bios_boot_flag, parser, skip_legacy_bootloader, 
-             bypass_workaround_flag, bypass_ms_account_flag, disable_bitlocker_flag)
+             bypass_hardware_check_flag, bypass_ms_account_flag, disable_bitlocker_flag)
     except KeyboardInterrupt:
         pass
     except Exception as error:

--- a/WoeUSB/gui.py
+++ b/WoeUSB/gui.py
@@ -310,7 +310,7 @@ class MainPanel(wx.Panel):
                 filesystem=filesystem, 
                 skip_grub=self.__parent.options_skip_grub.IsChecked(),
                 # Truyền các giá trị từ Popup xuống Handler
-                bypass_workaround=bypass_hw,
+                bypass_hardware_check=bypass_hw,
                 bypass_ms_account=bypass_ms,
                 disable_bitlocker=no_bitlocker
                 )
@@ -384,8 +384,8 @@ class DialogAbout(wx.Dialog):
         self.__NotebookAutorLicence = wx.Notebook(self, wx.ID_ANY)
 
         self.__NotebookAutorLicence.AddPage(
-            PanelNoteBookAutors(self.__NotebookAutorLicence, wx.ID_ANY, "slacka \nLin-Buo-Ren\nWaxyMocha", data_directory + "woeusb-logo.png",
-                                "github.com/WoeUSB/WoeUSB-ng"), _("Authors"), True)
+            PanelNoteBookAutors(self.__NotebookAutorLicence, wx.ID_ANY, "Nguyen12345tt\n (Based on work by slacka \nLin-Buo-Ren\nWaxyMocha)", data_directory + "woeusb-logo.png",
+                                "github.com/Nguyen12345tt/WoeUSB-ng"), _("Authors"), True)
         self.__NotebookAutorLicence.AddPage(
             PanelNoteBookAutors(self.__NotebookAutorLicence, wx.ID_ANY, "Colin GILLE / Congelli501",
                                 data_directory + "c501-logo.png", "www.congelli.eu"), _("Original WinUSB Developer"), False)
@@ -454,7 +454,7 @@ class WoeUSB_handler(threading.Thread):
     kill = False
 
     def __init__(self, source, target, boot_flag, filesystem, skip_grub=False, 
-                 bypass_workaround=False, bypass_ms_account=False, disable_bitlocker=False):
+                 bypass_hardware_check=False, bypass_ms_account=False, disable_bitlocker=False):
         threading.Thread.__init__(self)
 
         core.gui = self
@@ -463,7 +463,7 @@ class WoeUSB_handler(threading.Thread):
         self.boot_flag = boot_flag
         self.filesystem = filesystem
         self.skip_grub = skip_grub
-        self.bypass_workaround = bypass_workaround
+        self.bypass_hardware_check = bypass_hardware_check
         self.bypass_ms_account = bypass_ms_account
         self.disable_bitlocker = disable_bitlocker
 
@@ -477,7 +477,7 @@ class WoeUSB_handler(threading.Thread):
         try:
             core.main(source_fs_mountpoint, target_fs_mountpoint, self.source, self.target, "device", temp_directory,
                       self.filesystem, self.boot_flag , None, self.skip_grub, 
-                      self.bypass_workaround, self.bypass_ms_account, self.disable_bitlocker)
+                      self.bypass_hardware_check, self.bypass_ms_account, self.disable_bitlocker)
         except SystemExit:
             pass
 

--- a/WoeUSB/miscellaneous.py
+++ b/WoeUSB/miscellaneous.py
@@ -2,7 +2,7 @@ import gettext
 import locale
 import os
 
-__version__ = "0.2.12"
+__version__ = "0.2.13-alpha"
 
 translation = gettext.translation("woeusb", os.path.dirname(__file__) + "/locale", [locale.getlocale()[0]], fallback=True)
 translation.install()

--- a/WoeUSB/miscellaneous.py
+++ b/WoeUSB/miscellaneous.py
@@ -2,7 +2,7 @@ import gettext
 import locale
 import os
 
-__version__ = "0.2.13-alpha"
+__version__ = "0.2.14-alpha"
 
 translation = gettext.translation("woeusb", os.path.dirname(__file__) + "/locale", [locale.getlocale()[0]], fallback=True)
 translation.install()

--- a/WoeUSB/utils.py
+++ b/WoeUSB/utils.py
@@ -331,49 +331,47 @@ def update_policy_to_allow_for_running_gui_as_root(path):
     dom = parseString(
         "<?xml version=\"1.0\" ?>"
         "<!DOCTYPE policyconfig  PUBLIC '-//freedesktop//DTD polkit Policy Configuration 1.0//EN'  "
-        "'http://www.freedesktop.org/software/polkit/policyconfig-1.dtd'><!-- \n"
-        "DOC: https://www.freedesktop.org/software/polkit/docs/latest/polkit.8.html\n"
-        "--><policyconfig>\n"
-        "	<vendor>The WoeUSB Project</vendor>\n"
-        "	<vendor_url>https://github.com/slacka/WoeUSB</vendor_url>\n"
-        "	<icon_name>woeusbgui-icon</icon_name>\n"
+        "'http://www.freedesktop.org/software/polkit/policyconfig-1.dtd'><policyconfig>\n"
+        "   <vendor>The WoeUSB Project</vendor>\n"
+        "   <vendor_url>https://github.com/slacka/WoeUSB</vendor_url>\n"
+        "   <icon_name>woeusbgui-icon</icon_name>\n"
         "\n"
-        "	<action id=\"com.github.slacka.woeusb.run-gui-using-pkexec\">\n"
-        "		<description>Run `woeusb` as SuperUser</description>\n"
-        "		<description xml:lang=\"zh_TW\">以超級使用者(SuperUser)身份執行 `woeusb`</description>\n"
-        "		<description xml:lang=\"pl_PL\">Uruchom `woeusb` jako root</description>\n"
-        "		\n"
-        "		<message>Authentication is required to run `woeusb` as SuperUser.</message>\n"
-        "		<message xml:lang=\"zh_TW\">以超級使用者(SuperUser)身份執行 `woeusb` 需要通過身份驗證。</message>\n"
-        "		<message xml:lang=\"pl_PL\">Wymagana jest autoryzacja do uruchomienia `woeusb` jako root</message>\n"
-        "		\n"
-        "		<defaults>\n"
-        "			<allow_any>auth_admin</allow_any>\n"
-        "			<allow_inactive>auth_admin</allow_inactive>\n"
-        "			<allow_active>auth_admin_keep</allow_active>\n"
-        "		</defaults>\n"
-        "		\n"
-        "		<annotate key=\"org.freedesktop.policykit.exec.path\">/usr/local/bin/woeusbgui</annotate>\n"
-        "   		<annotate key=\"org.freedesktop.policykit.exec.allow_gui\">true</annotate>\n"
-        "	</action>\n"
-        "	<action id=\"com.github.slacka.woeusb.run-gui-using-pkexec-local\">\n"
-        "		<description>Run `woeusb` as SuperUser</description>\n"
-        "		<description xml:lang=\"zh_TW\">以超級使用者(SuperUser)身份執行 `woeusb`</description>\n"
-        "		<description xml:lang=\"pl_PL\">Uruchom `woeusb` jako root</description>\n"
+        "   <action id=\"com.github.slacka.woeusb.run-gui-using-pkexec\">\n"
+        "       <description>Run `woeusb` as SuperUser</description>\n"
+        "       <description xml:lang=\"zh_TW\">以超級使用者(SuperUser)身份執行 `woeusb`</description>\n"
+        "       <description xml:lang=\"pl_PL\">Uruchom `woeusb` jako root</description>\n"
+        "       \n"
+        "       <message>Authentication is required to run `woeusb` as SuperUser.</message>\n"
+        "       <message xml:lang=\"zh_TW\">以超級使用者(SuperUser)身份執行 `woeusb` 需要通過身份驗證。</message>\n"
+        "       <message xml:lang=\"pl_PL\">Wymagana jest autoryzacja do uruchomienia `woeusb` jako root</message>\n"
+        "       \n"
+        "       <defaults>\n"
+        "           <allow_any>auth_admin</allow_any>\n"
+        "           <allow_inactive>auth_admin</allow_inactive>\n"
+        "           <allow_active>auth_admin_keep</allow_active>\n"
+        "       </defaults>\n"
+        "       \n"
+        "       <annotate key=\"org.freedesktop.policykit.exec.path\">/usr/local/bin/woeusbgui</annotate>\n"
+        "           <annotate key=\"org.freedesktop.policykit.exec.allow_gui\">true</annotate>\n"
+        "   </action>\n"
+        "   <action id=\"com.github.slacka.woeusb.run-gui-using-pkexec-local\">\n"
+        "       <description>Run `woeusb` as SuperUser</description>\n"
+        "       <description xml:lang=\"zh_TW\">以超級使用者(SuperUser)身份執行 `woeusb`</description>\n"
+        "       <description xml:lang=\"pl_PL\">Uruchom `woeusb` jako root</description>\n"
         "\n"
-        "		<message>Authentication is required to run `woeusb` as SuperUser.</message>\n"
-        "		<message xml:lang=\"zh_TW\">以超級使用者(SuperUser)身份執行 `woeusb` 需要通過身份驗證。</message>\n"
-        "		<message xml:lang=\"pl_PL\">Wymagana jest autoryzacja do uruchomienia `woeusb` jako root</message>\n"
+        "       <message>Authentication is required to run `woeusb` as SuperUser.</message>\n"
+        "       <message xml:lang=\"zh_TW\">以超級使用者(SuperUser)身份執行 `woeusb` 需要通過身份驗證。</message>\n"
+        "       <message xml:lang=\"pl_PL\">Wymagana jest autoryzacja do uruchomienia `woeusb` jako root</message>\n"
         "\n"
-        "		<defaults>\n"
-        "			<allow_any>auth_admin</allow_any>\n"
-        "			<allow_inactive>auth_admin</allow_inactive>\n"
-        "			<allow_active>auth_admin_keep</allow_active>\n"
-        "		</defaults>\n"
+        "       <defaults>\n"
+        "           <allow_any>auth_admin</allow_any>\n"
+        "           <allow_inactive>auth_admin</allow_inactive>\n"
+        "           <allow_active>auth_admin_keep</allow_active>\n"
+        "       </defaults>\n"
         "\n"
-        "		<annotate key=\"org.freedesktop.policykit.exec.path\">/usr/local/bin/woeusbgui</annotate>\n"
-        "   		<annotate key=\"org.freedesktop.policykit.exec.allow_gui\">true</annotate>\n"
-        "	</action>\n"
+        "       <annotate key=\"org.freedesktop.policykit.exec.path\">/usr/local/bin/woeusbgui</annotate>\n"
+        "           <annotate key=\"org.freedesktop.policykit.exec.allow_gui\">true</annotate>\n"
+        "   </action>\n"
         "</policyconfig>"
     )
     for action in dom.getElementsByTagName('action'):
@@ -387,50 +385,44 @@ def update_policy_to_allow_for_running_gui_as_root(path):
 
 def write_win11_bypass(target_mountpoint, bypass_hardware=False, bypass_ms_account=False, disable_bitlocker=False):
     """
-    Tạo file autounattend.xml dựa trên các tùy chọn được bật.
+    Tạo file autounattend.xml với 2 giai đoạn (passes):
+    1. windowsPE: Để bypass kiểm tra phần cứng (Hardware Check).
+    2. specialize: Để bypass tài khoản MS và Bitlocker (Tác động vào hệ điều hành đã cài).
     """
     check_kill_signal()
     
     if not (bypass_hardware or bypass_ms_account or disable_bitlocker):
-        return True # Không làm gì nếu không có tùy chọn nào được bật
+        return True
 
     print_with_color(_("Writing Windows 11 custom configuration (autounattend.xml)..."), "green")
 
-    # Danh sách các lệnh Registry cần thêm
-    reg_commands = []
-
-    # 1. Bypass Hardware (TPM, SecureBoot, RAM)
+    # --- GIAI ĐOẠN 1: windowsPE (Chạy TRƯỚC khi cài đặt) ---
+    # Dùng để lừa bộ cài (Setup) bỏ qua kiểm tra phần cứng
+    pe_commands = []
     if bypass_hardware:
         base_path = r"HKLM\SYSTEM\Setup\LabConfig"
-        reg_commands.append(f"reg add {base_path} /v BypassTPMCheck /t REG_DWORD /d 1 /f")
-        reg_commands.append(f"reg add {base_path} /v BypassSecureBootCheck /t REG_DWORD /d 1 /f")
-        reg_commands.append(f"reg add {base_path} /v BypassRAMCheck /t REG_DWORD /d 1 /f")
-        reg_commands.append(f"reg add {base_path} /v BypassCPUCheck /t REG_DWORD /d 1 /f")
-        reg_commands.append(f"reg add {base_path} /v BypassStorageCheck /t REG_DWORD /d 1 /f")
+        pe_commands.append(f"reg add {base_path} /v BypassTPMCheck /t REG_DWORD /d 1 /f")
+        pe_commands.append(f"reg add {base_path} /v BypassSecureBootCheck /t REG_DWORD /d 1 /f")
+        pe_commands.append(f"reg add {base_path} /v BypassRAMCheck /t REG_DWORD /d 1 /f")
+        pe_commands.append(f"reg add {base_path} /v BypassCPUCheck /t REG_DWORD /d 1 /f")
+        pe_commands.append(f"reg add {base_path} /v BypassStorageCheck /t REG_DWORD /d 1 /f")
 
-    # 2. Bypass Microsoft Account (Network Requirement)
-    if bypass_ms_account:
-        reg_commands.append(r"reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE /v BypassNRO /t REG_DWORD /d 1 /f")
-
-    # 3. Disable BitLocker (Prevent Device Encryption)
-    if disable_bitlocker:
-        reg_commands.append(r"reg add HKLM\SYSTEM\CurrentControlSet\Control\BitLocker /v PreventDeviceEncryption /t REG_DWORD /d 1 /f")
-
-    # Tạo nội dung XML động
-    xml_commands = ""
-    for index, cmd in enumerate(reg_commands, start=1):
-        xml_commands += f"""
+    # Tạo nội dung XML cho windowsPE
+    xml_pe_content = ""
+    if pe_commands:
+        xml_pe_cmds = ""
+        for index, cmd in enumerate(pe_commands, start=1):
+            xml_pe_cmds += f"""
                 <RunSynchronousCommand wcm:action="add">
                     <Order>{index}</Order>
-                    <Path>{cmd}</Path>
+                    <Path>cmd /c {cmd}</Path>
                 </RunSynchronousCommand>"""
-
-    xml_content = f"""<?xml version="1.0" encoding="utf-8"?>
-<unattend xmlns="urn:schemas-microsoft-com:unattend">
+        
+        xml_pe_content = f"""
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <RunSynchronous>
-                {xml_commands}
+                {xml_pe_cmds}
             </RunSynchronous>
             <UserData>
                 <ProductKey>
@@ -439,14 +431,53 @@ def write_win11_bypass(target_mountpoint, bypass_hardware=False, bypass_ms_accou
                 <AcceptEula>true</AcceptEula>
             </UserData>
         </component>
-    </settings>
+    </settings>"""
+
+    # --- GIAI ĐOẠN 2: specialize (Chạy SAU khi cài, trước khi vào User) ---
+    # Dùng để tác động vào Windows thật trên ổ cứng (Bypass Account, BitLocker)
+    specialize_commands = []
+    
+    # 2. Bypass Microsoft Account (Network Requirement)
+    if bypass_ms_account:
+        # Quan trọng: Lệnh này phải chạy trên OS thật
+        specialize_commands.append(r"reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE /v BypassNRO /t REG_DWORD /d 1 /f")
+        
+    # 3. Disable BitLocker
+    if disable_bitlocker:
+        specialize_commands.append(r"reg add HKLM\SYSTEM\CurrentControlSet\Control\BitLocker /v PreventDeviceEncryption /t REG_DWORD /d 1 /f")
+
+    # Tạo nội dung XML cho specialize
+    xml_specialize_content = ""
+    if specialize_commands:
+        xml_specialize_cmds = ""
+        for index, cmd in enumerate(specialize_commands, start=1):
+            xml_specialize_cmds += f"""
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>{index}</Order>
+                    <Path>cmd /c {cmd}</Path>
+                </RunSynchronousCommand>"""
+
+        xml_specialize_content = f"""
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                {xml_specialize_cmds}
+            </RunSynchronous>
+        </component>
+    </settings>"""
+
+    # Gộp toàn bộ file XML
+    full_xml_content = f"""<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    {xml_pe_content}
+    {xml_specialize_content}
 </unattend>"""
 
     target_file = os.path.join(target_mountpoint, "autounattend.xml")
 
     try:
         with open(target_file, "w") as f:
-            f.write(xml_content)
+            f.write(full_xml_content)
         print_with_color(_("Success: autounattend.xml created at {0}").format(target_file), "green")
         return True
     except IOError as e:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,14 +19,14 @@ sys.path.insert(0, os.path.abspath('../src'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'WoeUSB'
-copyright = '2018, congelli501, slacka and WaxyMocha et. al.'
-author = 'congelli501, slacka and WaxyMocha et. al.'
+project = 'WoeUSB+'
+copyright = '2018-2026, congelli501, slacka, WaxyMocha, Nguyen12345tt, et. al.'
+author = 'Nguyen12345tt, based on work by congelli501, slacka and WaxyMocha et. al.'
 
 # The short X.Y version
-version = ''
+version = '0.2'
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+release = '0.2.14-alpha'
 
 
 # -- General configuration ---------------------------------------------------
@@ -131,7 +131,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'WoeUSB.tex', 'WoeUSB Documentation',
-     'congelli501, slacka and WaxyMocha et. al.', 'manual'),
+    'Nguyen12345tt, congelli501, slacka and WaxyMocha et. al.', 'manual'),
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ class PostInstallCommand(install):
 
 setup(
     name='WoeUSB-ng',
-    version='0.2.12',
+    version='0.2.13-alpha',
     description='WoeUSB-ng is a simple tool that enable you to create your own usb stick windows installer from an iso image or a real DVD. This is a rewrite of original WoeUSB. ',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,23 @@ class PostInstallCommand(install):
 
 setup(
     name='WoeUSB-ng',
-    version='0.2.13-alpha',
-    description='WoeUSB-ng is a simple tool that enable you to create your own usb stick windows installer from an iso image or a real DVD. This is a rewrite of original WoeUSB. ',
+    version='0.2.14-alpha',
+    
+    # Add 
+    description='WoeUSB-ng fork with Windows 11 Bypass (TPM, SecureBoot, MS Account) & BitLocker fix. Originally by congelli501 & slacka.',
+    
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://github.com/WoeUSB/WoeUSB-ng',
-    author='Jakub Szymański',
-    author_email='jakubmateusz@poczta.onet.pl',
+    
+    # SỬA DÒNG NÀY: Link về kho GitHub của bạn
+    url='https://github.com/Nguyen12345tt/WoeUSB-ng', 
+    
+    # SỬA DÒNG NÀY: Để khẳng định chủ quyền
+    author='Nguyen12345tt', 
+    
+    # SỬA DÒNG NÀY: Email của bạn (để trống hoặc điền email thật)
+    author_email='thanhnguyennguyen496@gmail.com',
+    
     license='GPL-3',
     zip_safe=False,
     packages=['WoeUSB'],


### PR DESCRIPTION
Disclaimer:
This alpha version is for testing only.
It is not ready for daily use and we do not guarantee its usability.
If you discovered an issue and you do not have debugging skills, please check with the in advance before opening an Issue.

The latest updates are:
Feat: Add Windows 11 bypass options (TPM, MS Account, BitLocker)
Chore: Bump version to 0.2.13-alpha